### PR TITLE
Add environmental variable interface from runner to tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ Flask==0.10.1
 Jinja2==2.8
 MarkupSafe==0.23
 Werkzeug==0.10.4
-matplotlib==1.4.3
+#matplotlib==1.4.3
 mpld3==0.2
-numpy==1.9.2
-pandas==0.16.2
+#numpy==1.9.2
+#pandas==0.16.2
 python-dateutil==2.4.2
 pytest==2.7.2
 pytz==2015.4

--- a/scripts/hadoopinspector_runner.py
+++ b/scripts/hadoopinspector_runner.py
@@ -28,6 +28,8 @@ def main():
     check_results  = core.CheckResults()
 
     checker    = CheckRunner(registry, check_repo, check_results)
+    checker.store_variable_to_env('hapinsp_instance', args.instance)
+    checker.store_variable_to_env('hapinsp_database', args.database)
     checker.run_checks_for_tables(args.table)
 
     if args.report:
@@ -92,6 +94,9 @@ class CheckRunner(object):
         self.registry = registry
         self.results  = check_results
 
+    def store_variable_to_env(self, key, value):
+        os.putenv(key, value)
+
 
     def run_checks_for_tables(self, table):
         """
@@ -102,6 +107,7 @@ class CheckRunner(object):
         for instance in self.registry.db_registry:
             for database in self.registry.db_registry[instance]:
                 for table in self.registry.db_registry[instance][database]:
+                    self.store_variable_to_env('hapinsp_table', table)
                     for check in self.registry.db_registry[instance][database][table]:
                         reg_check = self.registry.db_registry[instance][database][table][check]
                         if reg_check['check_status'] == 'active':

--- a/scripts/tests/test_hadoopinspector_runner_functional.py
+++ b/scripts/tests/test_hadoopinspector_runner_functional.py
@@ -195,6 +195,59 @@ class TestWithMockedCheckFiles(object):
         assert str(run_rc) == expected_run_rc
 
 
+    def test_check_env_variable_table(self):
+        table                  = 'customer'
+        expected_check_cnt     = 1
+        expected_check_rc      = '0'
+        expected_run_rc        = '0'
+        expected_violation_cnt = '0'
+        check_fqfn = add_env_check(self.check_dir, key='hapinsp_table', value='customer')
+        os.system("cat %s" % check_fqfn)
+        self.registry_fqfn = add_to_registry(self.registry_fqfn, self.inst, self.db,
+                             table, self.check_dir, check_fqfn)
+
+        report, run_rc = self.run_cmd()
+
+        report_checker(report, expected_check_cnt, expected_check_rc, expected_violation_cnt)
+        assert str(run_rc) == expected_run_rc
+
+    def test_check_env_variables_database(self):
+        table                  = 'customer'
+        expected_check_cnt     = 1
+        expected_check_rc      = '0'
+        expected_run_rc        = '0'
+        expected_violation_cnt = '0'
+        check_fqfn = add_env_check(self.check_dir, key='hapinsp_database', value=self.db)
+        os.system("cat %s" % check_fqfn)
+        self.registry_fqfn = add_to_registry(self.registry_fqfn, self.inst, self.db,
+                             table, self.check_dir, check_fqfn)
+
+        report, run_rc = self.run_cmd()
+
+        report_checker(report, expected_check_cnt, expected_check_rc, expected_violation_cnt)
+        assert str(run_rc) == expected_run_rc
+
+    def test_check_env_variables_instance(self):
+        table                  = 'customer'
+        expected_check_cnt     = 1
+        expected_check_rc      = '0'
+        expected_run_rc        = '0'
+        expected_violation_cnt = '0'
+        check_fqfn = add_env_check(self.check_dir, key='hapinsp_instance', value=self.inst)
+        os.system("cat %s" % check_fqfn)
+        self.registry_fqfn = add_to_registry(self.registry_fqfn, self.inst, self.db,
+                             table, self.check_dir, check_fqfn)
+
+        report, run_rc = self.run_cmd()
+
+        report_checker(report, expected_check_cnt, expected_check_rc, expected_violation_cnt)
+        assert str(run_rc) == expected_run_rc
+
+
+
+
+
+
 def add_to_registry(registry_fn, inst, db, table, check_dir, check_fn):
 
    check_alias  = os.path.splitext(basename(check_fn))[0]
@@ -228,6 +281,29 @@ def add_check(check_dir, rc, out_count):
     st = os.stat(fqfn)
     os.chmod(fqfn, st.st_mode | stat.S_IEXEC)
     return fqfn
+
+
+def add_env_check(check_dir, key, value):
+
+    for check_id in range(1000):
+       fqfn = pjoin(check_dir, 'check_%d.bash' % check_id)
+       if not isfile(fqfn):
+           break
+
+    with open(fqfn, 'w') as f:
+        f.write("""#!/usr/bin/env bash \n """ )
+        f.write('\n')
+        f.write(""" if [ "$%s" = "%s"  ]; then \n""" % (key, value))
+        f.write("""     outcount=0 \n""")
+        f.write(""" else \n""")
+        f.write("""     outcount=1 \n""")
+        f.write(""" fi \n""")
+        f.write(""" echo "violation_cnt: $outcount " \n""" )
+        f.write(""" exit 0 \n """)
+    st = os.stat(fqfn)
+    os.chmod(fqfn, st.st_mode | stat.S_IEXEC)
+    return fqfn
+
 
 
 def report_checker(report, expected_check_cnt, expected_check_rc, expected_violation_cnt):


### PR DESCRIPTION
Includes:
   - Automatic writing of hadoop instance, database and table to
     environmental vars.  This allows tests to access this info easily,
     and use it to customize their behavior - enabling very generic tests.
   - Also eliminated some unnecessary requirements (housekeeping)